### PR TITLE
fix(crates): correct a typo in dependent library and add guide for running tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,17 @@ Tags follow this convention `v{x.y.z}+sgx{x.y.z}`, where:
 - Provide a diff of your changes for reviewing and auditing.
 - Add metadata in the crates section of `README.md` and update `CHANGELOG.md`.
 
+### Test
+
+To run unit tests for all crates maintained by this repository, just run
+
+```bash
+# in simulated mode
+SGX_MODE=SW make test
+
+# or hardware mode with 'make test'
+```
+
 ## Porting
 
 1. Fix dependencies: add SGX related dependencies in the Cargo.toml. For example:

--- a/crates/cfg-if/sgx-tests/Makefile
+++ b/crates/cfg-if/sgx-tests/Makefile
@@ -60,7 +60,7 @@ App_Name := bin/run-tests
 ######## Enclave Settings ########
 
 ifneq ($(SGX_MODE), HW)
-	Trts_Library_Name := sgx_trts_si	m
+	Trts_Library_Name := sgx_trts_sim
 	Service_Library_Name := sgx_tservice_sim
 else
 	Trts_Library_Name := sgx_trts

--- a/crates/itoa/sgx-tests/Makefile
+++ b/crates/itoa/sgx-tests/Makefile
@@ -60,7 +60,7 @@ App_Name := bin/run-tests
 ######## Enclave Settings ########
 
 ifneq ($(SGX_MODE), HW)
-	Trts_Library_Name := sgx_trts_si	m
+	Trts_Library_Name := sgx_trts_sim
 	Service_Library_Name := sgx_tservice_sim
 else
 	Trts_Library_Name := sgx_trts

--- a/crates/rust-hex/sgx-tests/Makefile
+++ b/crates/rust-hex/sgx-tests/Makefile
@@ -60,12 +60,13 @@ App_Name := bin/run-tests
 ######## Enclave Settings ########
 
 ifneq ($(SGX_MODE), HW)
-	Trts_Library_Name := sgx_trts_si	m
+	Trts_Library_Name := sgx_trts_sim
 	Service_Library_Name := sgx_tservice_sim
 else
 	Trts_Library_Name := sgx_trts
 	Service_Library_Name := sgx_tservice
 endif
+
 Crypto_Library_Name := sgx_tcrypto
 KeyExchange_Library_Name := sgx_tkey_exchange
 ProtectedFs_Library_Name := sgx_tprotected_fs


### PR DESCRIPTION

### Description

#### Fixes
- `sgx_trts_si	m` is corrected as `sgx_trts_sim` with the mistyped whitespaces removed

#### Docs
- Describe how to run tests in README