### PR TITLE
Add anyhow 1.0.28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [Unreleased]
+- Add anyhow 1.0.28
+
 ## [0.2.0]
 - Update to Teaclave SGX SDK 1.1.1
 - Add itoa 0.4.5

--- a/meta.txt
+++ b/meta.txt
@@ -1,4 +1,5 @@
-project name, version, upstream URL, upstream commit hash base, license
-cfg-if, 0.1.10, https://github.com/alexcrichton/cfg-if, 4484a6faf816ff8058088ad857b0c6bb2f4b02b2, MIT/Apache-2.0
-itoa, 0.4.5, https://github.com/dtolnay/itoa, 0ecba421fa2f278431d1e0ab607d9311ad2c1541, MIT/Apache-2.0
-rust-hex, 0.4.2, https://github.com/KokaKiwi/rust-hex, be0c32f9c8938ca0359bbb0d1477e31b07cb3358, MIT/Apache-2.0
+project name, version, upstream URL, upstream commit hash base, license, tests (none, partial, full)
+anyhow, 1.0.28,https://github.com/dtolnay/anyhow, 022f700a1c67c5cd663c34b8a3c11c6818ec0ecb, MIT/Apache-2.0, partial
+cfg-if, 0.1.10, https://github.com/alexcrichton/cfg-if, 4484a6faf816ff8058088ad857b0c6bb2f4b02b2, MIT/Apache-2.0, full
+itoa, 0.4.5, https://github.com/dtolnay/itoa, 0ecba421fa2f278431d1e0ab607d9311ad2c1541, MIT/Apache-2.0, full
+rust-hex, 0.4.2, https://github.com/KokaKiwi/rust-hex, be0c32f9c8938ca0359bbb0d1477e31b07cb3358, MIT/Apache-2.0, full

--- a/utils/sgx-tests-template/Makefile
+++ b/utils/sgx-tests-template/Makefile
@@ -60,7 +60,7 @@ App_Name := bin/run-tests
 ######## Enclave Settings ########
 
 ifneq ($(SGX_MODE), HW)
-	Trts_Library_Name := sgx_trts_si	m
+	Trts_Library_Name := sgx_trts_sim
 	Service_Library_Name := sgx_tservice_sim
 else
 	Trts_Library_Name := sgx_trts


### PR DESCRIPTION
## Add Crates

### Description

Add anyhow 1.0.28. Tests is partially ported because some test dependencies is not ready.

### Crate Meta

- **Name**: anyhow
- **Version**: 1.0.28
- **License**: MIT/Apache-2.0
- **Upstream commit hash base**: 022f700a1c67c5cd663c34b8a3c11c6818ec0ecb
- **Teaclave SGX SDK version**: 1.1.1

### Diff of Changes

```diff
diff --git a/Cargo.toml b/Cargo.toml
index 011c7c9..c6ed8aa 100644
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,12 @@ categories = ["rust-patterns"]
 travis-ci = { repository = "dtolnay/anyhow" }
 
 [features]
-default = ["std"]
+default = ["std", "mesalock_sgx"]
 std = []
+mesalock_sgx = ["std", "sgx_tstd", "sgx_tstd/backtrace"]
+
+[dependencies]
+sgx_tstd = { git = "https://github.com/apache/incubator-teaclave-sgx-sdk.git", tag = "v1.1.1", optional = true }
 
 [dev-dependencies]
 futures = { version = "0.3", default-features = false }
diff --git a/build.rs b/build.rs
deleted file mode 100644
index 056164d..0000000
--- a/build.rs
+++ /dev/null
@@ -1,62 +0,0 @@
-use std::env;
-use std::fs;
-use std::path::Path;
-use std::process::{Command, ExitStatus};
-
-// This code exercises the surface area that we expect of the std Backtrace
-// type. If the current toolchain is able to compile it, we go ahead and use
-// backtrace in anyhow.
-const PROBE: &str = r#"
-    #![feature(backtrace)]
-    #![allow(dead_code)]
-
-    use std::backtrace::{Backtrace, BacktraceStatus};
-    use std::error::Error;
-    use std::fmt::{self, Display};
-
-    #[derive(Debug)]
-    struct E;
-
-    impl Display for E {
-        fn fmt(&self, _formatter: &mut fmt::Formatter) -> fmt::Result {
-            unimplemented!()
-        }
-    }
-
-    impl Error for E {
-        fn backtrace(&self) -> Option<&Backtrace> {
-            let backtrace = Backtrace::capture();
-            match backtrace.status() {
-                BacktraceStatus::Captured | BacktraceStatus::Disabled | _ => {}
-            }
-            unimplemented!()
-        }
-    }
-"#;
-
-fn main() {
-    if !cfg!(feature = "std") {
-        return;
-    }
-    match compile_probe() {
-        Some(status) if status.success() => println!("cargo:rustc-cfg=backtrace"),
-        _ => {}
-    }
-}
-
-fn compile_probe() -> Option<ExitStatus> {
-    let rustc = env::var_os("RUSTC")?;
-    let out_dir = env::var_os("OUT_DIR")?;
-    let probefile = Path::new(&out_dir).join("probe.rs");
-    fs::write(&probefile, PROBE).ok()?;
-    Command::new(rustc)
-        .arg("--edition=2018")
-        .arg("--crate-name=anyhow_build")
-        .arg("--crate-type=lib")
-        .arg("--emit=metadata")
-        .arg("--out-dir")
-        .arg(out_dir)
-        .arg(probefile)
-        .status()
-        .ok()
-}
diff --git a/src/chain.rs b/src/chain.rs
index 207e4f0..a35bd81 100644
--- a/src/chain.rs
+++ b/src/chain.rs
@@ -4,6 +4,9 @@ use crate::StdError;
 #[cfg(feature = "std")]
 use std::vec;
 
+#[cfg(feature = "std")]
+use std::prelude::v1::*;
+
 #[cfg(feature = "std")]
 pub(crate) use crate::Chain;
 
diff --git a/src/kind.rs b/src/kind.rs
index fdeb060..a18db26 100644
--- a/src/kind.rs
+++ b/src/kind.rs
@@ -50,6 +50,9 @@ use core::fmt::{Debug, Display};
 #[cfg(feature = "std")]
 use crate::StdError;
 
+#[cfg(feature = "std")]
+use std::prelude::v1::*;
+
 #[cfg(backtrace)]
 use std::backtrace::Backtrace;
 
diff --git a/src/lib.rs b/src/lib.rs
index c6694ab..d8b8cc8 100644
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,6 +198,13 @@
     clippy::new_ret_no_self,
     clippy::wrong_self_convention
 )]
+#![cfg_attr(all(feature = "mesalock_sgx",
+                not(target_env = "sgx")), no_std)]
+#![cfg_attr(all(target_env = "sgx", target_vendor = "mesalock"),
+            feature(rustc_private))]
+#[cfg(all(feature = "mesalock_sgx", not(target_env = "sgx")))]
+#[macro_use]
+extern crate sgx_tstd as std;
 
 mod alloc {
     #[cfg(not(feature = "std"))]
diff --git a/src/wrapper.rs b/src/wrapper.rs
index 3ebe51a..9cdd98a 100644
--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -1,6 +1,9 @@
 use crate::StdError;
 use core::fmt::{self, Debug, Display};
 
+#[cfg(feature = "std")]
+use std::prelude::v1::*;
+
 #[repr(transparent)]
 pub struct MessageError<M>(pub M);
 ```
